### PR TITLE
Improve Ascension detection and spell lookup

### DIFF
--- a/GSE/API/Ascension.lua
+++ b/GSE/API/Ascension.lua
@@ -9,6 +9,9 @@ function GSE.IsAscension()
       return true
     end
   end
+  if LibStub and LibStub:GetLibrary("LibAscensionConfig", true) then
+    return true
+  end
   return false
 end
 
@@ -17,13 +20,17 @@ function GSE.ResolveSpell(ref)
   if spellCache[ref] ~= nil then
     return spellCache[ref]
   end
-  local name, _, icon = GetSpellInfo(ref)
+  local lookup = ref
+  if type(ref) == "string" and tonumber(ref) then
+    lookup = tonumber(ref)
+  end
+  local name, _, icon, _, _, _, spellId = GetSpellInfo(lookup)
   if not name then
     GSE.Log("WARN", "Unknown spell " .. tostring(ref))
     spellCache[ref] = nil
     return nil
   end
-  local id = type(ref) == "number" and ref or select(7, GetSpellInfo(name))
+  local id = type(ref) == "number" and ref or spellId
   local result = {name = name, id = id, icon = icon}
   spellCache[ref] = result
   return result

--- a/PORT_NOTES.md
+++ b/PORT_NOTES.md
@@ -5,6 +5,8 @@
 
 ## Ascension Support
 - Added `GSE/API/Ascension.lua` detecting Ascension client and resolving spells safely through a cache.
+- Improved detection via `LibAscensionConfig` for clients where the `portal` CVar isn't set.
+- `ResolveSpell` now supports numeric strings and performs a single `GetSpellInfo` lookup.
 
 ## Limitations
 - Spec-based features are disabled on Ascension where `GetSpecialization` is unavailable.


### PR DESCRIPTION
## Summary
- Detect Ascension clients via `LibAscensionConfig` when the `portal` CVar is absent
- Resolve spells from numeric strings and cache lookups with a single `GetSpellInfo` call
- Document enhanced Ascension detection and spell resolution details in port notes

## Testing
- `luacheck GSE/API/Ascension.lua` *(fails: luacheck not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68adc0a4f01c832886c4e78101102bc7