### PR TITLE
Add slash command to display addon version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Initial Ascension compatibility port with Lua 5.1 fixes.
 - Added spell resolution cache and Ascension detection.
 - Added defensive event registration and nil-safe string helpers.
+- Added `/gse version` command to display the current addon version.

--- a/GSE/API/Events.lua
+++ b/GSE/API/Events.lua
@@ -343,6 +343,7 @@ local function PrintGnomeHelp()
   GSE.Print(L["The command "] .. GSEOptions.CommandColour .. L["/gs checkmacrosforerrors|r will loop through your macros and check for corrupt macro versions.  This will then show how to correct these issues."], GNOME)
   GSE.Print(L["The command "] .. GSEOptions.CommandColour .. L["/gse cleancorrupted|r will remove corrupted sequences that cannot be edited or deleted through the interface."], GNOME)
   GSE.Print(L["The command "] .. GSEOptions.CommandColour .. L["/gse loadsamples|r will load documented sample macros for your current class."], GNOME)
+  GSE.Print(L["The command "] .. GSEOptions.CommandColour .. L["/gse version|r will display the current version of GSE."], GNOME)
 end
 
 GSE:RegisterChatCommand("gsse", "GSSlash")
@@ -397,6 +398,8 @@ function GSE:GSSlash(input)
     else
       GSE.Print(L["Sample macros are not available."], GNOME)
     end
+  elseif string.lower(input) == "version" then
+    GSE.Print(string.format(L["GSE Version: %s"], GSE.formatModVersion(GSE.VersionString)), GNOME)
   elseif string.lower(input) == "cleancorrupted" then
     GSE.CleanCorruptedSequences()
   else

--- a/GSE/Localization/ModL_enUS.lua
+++ b/GSE/Localization/ModL_enUS.lua
@@ -40,6 +40,7 @@ L["New: Type "] = true
 L["|r to load sample macros for your class."] = true
 L["/gse cleancorrupted|r will remove corrupted sequences that cannot be edited or deleted through the interface."] = true
 L["/gse loadsamples|r will load documented sample macros for your current class."] = true
+L["/gse version|r will display the current version of GSE."] = true
 L["/gs checkmacrosforerrors|r will loop through your macros and check for corrupt macro versions.  This will then show how to correct these issues."] = true
 L["Version="] = true
 L[":|r You cannot delete the only copy of a sequence."] = true

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ GSE (Gnome Sequencer Enhanced) is an advanced macro sequencer for World of Warcr
 - `/gse showspec` - Show your current specialization
 - `/gse loadsamples` - Load sample macros for your class
 - `/gse debug` - Toggle debug mode
+- `/gse version` - Display the current addon version
 
 ### Creating Your First Macro
 1. Type `/gse` to open the interface


### PR DESCRIPTION
## Summary
- add `/gse version` slash command to print the current addon version
- document version command in help text, localization, README, and changelog

## Testing
- `make dist`

------
https://chatgpt.com/codex/tasks/task_e_68ae1e3313148328aea3b226c72f438e